### PR TITLE
fix: Correctly map dotty to localhost port in development yaml file

### DIFF
--- a/docker-compose.override.yml-dev
+++ b/docker-compose.override.yml-dev
@@ -40,7 +40,7 @@ services:
       - "3004:80"
 
   # map dotty to port 3005
-  nginx:
+  dotty:
     ports:
       - "3005:8080"
 


### PR DESCRIPTION
Probably that was typo, but however it caused bug(