### PR TITLE
fix: Proper naming of cada-prio container

### DIFF
--- a/docker-compose.override.yml-dev
+++ b/docker-compose.override.yml-dev
@@ -46,7 +46,7 @@ services:
       - "3005:8080"
 
   # map cada-prio to port 3006
-  prio:
+  cada-prio:
     ports:
       - "3006:8080"
 


### PR DESCRIPTION
Just a minor fix `prio` -> `cada-prio`